### PR TITLE
Fix linter warnings + use named async chunks

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -6,10 +6,14 @@ const main = async () => {
   console.log('Dependency 1 value:', dep1);
   console.log('Dependency 2 value:', dep2);
 
-  const {import1} = await import('./import-1.js');
+  const {import1} = await import(
+    /* webpackChunkName: "import1" */
+    './import-1.js');
   console.log('Dynamic Import 1 value:', import1);
 
-  const {import2} = await import('./import-2.js');
+  const {import2} = await import(
+    /* webpackChunkName: "import2" */
+    './import-2.js');
   console.log('Dynamic Import 2 value:', import2);
 
   console.log('Fetching data, awaiting response...');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,6 @@
 <body>
   {% include 'nomodule-shim.html' %}
   <script nomodule src="{{ 'runtime.es5.js' | revision }}"></script>
-  <script nomodule src="{{ 'main.es5.js' | revision }}"></script>
+  <script nomodule src="{{ 'main-legacy.es5.js' | revision }}"></script>
 </body>
 </html>

--- a/tasks/bundles.js
+++ b/tasks/bundles.js
@@ -1,6 +1,4 @@
-const fs = require('fs-extra');
 const md5 = require('md5');
-const NameAllModulesPlugin = require('name-all-modules-plugin');
 const path = require('path');
 const TerserPlugin = require('terser-webpack-plugin');
 const webpack = require('webpack');
@@ -18,8 +16,8 @@ const configurePlugins = () => {
         return md5(Array.from(chunk.modulesIterable, (m) => {
           return m.identifier();
         }).join()).slice(0, 10);
-      }
-      return chunk.name ? chunk.name : hashChunk()
+      };
+      return chunk.name ? chunk.name : hashChunk();
     }),
 
     new ManifestPlugin({
@@ -30,7 +28,7 @@ const configurePlugins = () => {
           // Needed until this issue is resolved:
           // https://github.com/danethurber/webpack-manifest-plugin/issues/159
           const unhashedName = path.basename(opts.path)
-              .replace(/[_\.\-][0-9a-f]{10}/, '')
+              .replace(/[_.-][0-9a-f]{10}/, '');
 
           addAsset(unhashedName, opts.path);
           return getManifest();

--- a/tasks/bundles.js
+++ b/tasks/bundles.js
@@ -108,7 +108,7 @@ const modernConfig = Object.assign({}, baseConfig, {
 
 const legacyConfig = Object.assign({}, baseConfig, {
   entry: {
-    'main': './app/scripts/main-legacy.js',
+    'main-legacy': './app/scripts/main-legacy.js',
   },
   output: {
     path: path.resolve(__dirname, '..', config.publicDir),


### PR DESCRIPTION
Hi Phil, thanks for great work!

I added a few small enhancements, hopefully they make sense to you.

1. When I ran `npm start` after fresh clone, it inserted semicolons and complained about unnecessary `\` in regex and unused deps. Probably some minor npm deps upgrade behind the scenes

2. I also added webpack magic comments to output files with readable names.
3. Renamed `main-legacy` chunk so that it's easier to run webpack output in console and distinguish the two builds